### PR TITLE
Ci and fix for native engines

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,75 @@
+name: 'Tests'
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test-jvm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: ./gradlew jvmTest
+
+      - name: Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure()
+        with:
+          check_name: 'JVM Test Reports'
+          report_paths: '**/build/test-results/jvmTest/TEST-*.xml'
+
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install libcurl
+        run: sudo apt-get install -y libcurl4-gnutls-dev
+
+      - name: Run tests
+        run: ./gradlew nativeTest
+
+      - name: Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure()
+        with:
+          check_name: 'Linux Test Reports'
+          report_paths: '**/build/test-results/nativeTest/TEST-*.xml'
+
+  test-darwin:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: ./gradlew nativeTest
+
+      - name: Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure()
+        with:
+          check_name: 'Darwin Test Reports'
+          report_paths: '**/build/test-results/nativeTest/TEST-*.xml'
+
+  test-mingw:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: ./gradlew nativeTest
+
+      - name: Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure()
+        with:
+          check_name: 'Mingw Test Reports'
+          report_paths: '**/build/test-results/nativeTest/TEST-*.xml'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
     when {
         hostOs == "Mac OS X" && isArm64 -> macosArm64("native")
         hostOs == "Mac OS X" && !isArm64 -> macosX64("native")
-        hostOs == "Linux" && isArm64 -> linuxArm64("native")
         hostOs == "Linux" && !isArm64 -> linuxX64("native")
         isMingwX64 -> mingwX64("native")
         else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
@@ -58,7 +57,13 @@ kotlin {
         val jvmTest by getting
         val nativeMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-darwin:$ktorVersion")
+                when {
+                    hostOs == "Mac OS X" -> implementation("io.ktor:ktor-client-darwin:$ktorVersion")
+                    hostOs == "Linux"-> implementation("io.ktor:ktor-client-curl:$ktorVersion")
+                    isMingwX64 -> implementation("io.ktor:ktor-client-winhttp:$ktorVersion")
+                    else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+                }
+
             }
         }
         val nativeTest by getting


### PR DESCRIPTION
close #1 
close #5 

We also drop support for linuxArm64 because there is no engine that supports this 😅 

Note:
For whatever reasons, I have to use the `gnutls` version of libcurl. 
`libcurl-openssl` doesn't work 🤷 
https://packages.ubuntu.com/focal/libcurl4-gnutls-dev
https://packages.ubuntu.com/focal/libcurl4-openssl-dev
See also https://serverfault.com/a/938944