### PR TITLE
Introduce second Lokalise factory function

### DIFF
--- a/src/commonMain/kotlin/com/ioki/lokalise/api/LokaliseClient.kt
+++ b/src/commonMain/kotlin/com/ioki/lokalise/api/LokaliseClient.kt
@@ -85,6 +85,14 @@ interface LokaliseQueuedProcesses {
 fun Lokalise(
     token: String,
     fullLoggingEnabled: Boolean = false,
+): Lokalise = Lokalise(token, fullLoggingEnabled, null)
+
+/**
+ * Creates a new [Lokalise] object.
+ */
+internal fun Lokalise(
+    token: String,
+    fullLoggingEnabled: Boolean = false,
     httpClientEngine: HttpClientEngine? = null
 ): Lokalise {
 


### PR DESCRIPTION
Otherwise the HttpClientEngine would leak into the api classpath and therefore needs to be an API dependency.
I don't want this so I made this internal.