### PR TITLE
Add `dokkaHtml` jar file to publications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.kotlinDokka)
     `maven-publish`
 }
 
@@ -51,11 +52,18 @@ kotlin {
     }
 }
 
+val dokkaJar = tasks.register<Jar>("dokkaJar") {
+    dependsOn(tasks.dokkaHtml)
+    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
+    archiveClassifier.set("javadoc")
+}
+
 group = "com.ioki"
 version = "0.0.2-SNAPSHOT"
 publishing {
     publications {
         publications.withType<MavenPublication> {
+            artifact(dokkaJar)
             artifactId = artifactId.replace("kmp-", "")
             pom {
                 url.set("https://github.com/ioki-mobility/kmp-lokalise-api")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,3 +23,4 @@ mingw-ktor-client = { module = "io.ktor:ktor-client-winhttp", version.ref = "kto
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinDokka = "org.jetbrains.dokka:1.9.10"


### PR DESCRIPTION
We are now including a javadoc jar file to our publications.
Now each of an additional `jar` file with the `javadoc` classifier:

![Screenshot 2023-11-22 at 10 54 53 AM](https://github.com/ioki-mobility/kmp-lokalise-api/assets/10229883/ff074c8a-0f50-4a18-8ddd-c329742d1b4e)

Extracting it will display something like this:
![Screenshot 2023-11-22 at 10 54 47 AM](https://github.com/ioki-mobility/kmp-lokalise-api/assets/10229883/a86e77c6-3b83-47de-85c1-4f6bd21a5ad7)

(which is navigateable and stuff).

This is one requirement for #33 
