### PR TITLE
Add new field `key_count_deleted`

### DIFF
--- a/src/commonMain/kotlin/com/ioki/lokalise/api/models/RetrievedProcess.kt
+++ b/src/commonMain/kotlin/com/ioki/lokalise/api/models/RetrievedProcess.kt
@@ -35,6 +35,7 @@ data class RetrievedProcess(
                 @SerialName("key_count_inserted") val keyCountInserted: Int,
                 @SerialName("key_count_updated") val keyCountUpdated: Int,
                 @SerialName("key_count_skipped") val keyCountSkipped: Int,
+                @SerialName("key_count_deleted") val keyCountDeleted: Int,
             )
         }
     }

--- a/src/commonTest/kotlin/com/ioki/lokalise/api/stubs/RetrieveProcessJson.kt
+++ b/src/commonTest/kotlin/com/ioki/lokalise/api/stubs/RetrieveProcessJson.kt
@@ -23,7 +23,8 @@ val retrieveProcessJson = """
           "key_count_total": 1,
           "key_count_inserted": 0,
           "key_count_updated": 0,
-          "key_count_skipped": 1
+          "key_count_skipped": 1,
+          "key_count_deleted": 1
         }
       ]
     }


### PR DESCRIPTION
The Lokalise API seems to have changed. The `receive process` endpoint response with a new field `key_count_deleted`.

Until now it's **not** documented. The [changelog](https://developers.lokalise.com/docs/api-changelog) and the [API documentation](https://developers.lokalise.com/reference/retrieve-a-process) are not containing any information about this.

We should thinking about to enable `ignoreUnknownKeys` option. This prevent us from errors when new fields are added by Lokalise.