### PR TITLE
Ignore unknown response fields

### DIFF
--- a/src/commonMain/kotlin/com/ioki/lokalise/api/LokaliseClient.kt
+++ b/src/commonMain/kotlin/com/ioki/lokalise/api/LokaliseClient.kt
@@ -21,6 +21,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -99,7 +100,7 @@ internal fun Lokalise(
 ): Lokalise {
     val clientConfig: HttpClientConfig<*>.() -> Unit = {
         install(ContentNegotiation) {
-            json()
+            json(Json{ ignoreUnknownKeys = true })
         }
         install(Logging) {
             level = if (fullLoggingEnabled) LogLevel.ALL else LogLevel.HEADERS

--- a/src/commonTest/kotlin/com/ioki/lokalise/api/LokaliseClientTest.kt
+++ b/src/commonTest/kotlin/com/ioki/lokalise/api/LokaliseClientTest.kt
@@ -2,6 +2,7 @@ package com.ioki.lokalise.api
 
 import com.ioki.lokalise.api.stubs.errorJson
 import com.ioki.lokalise.api.stubs.fileDownloadJson
+import com.ioki.lokalise.api.stubs.fileDownloadWithUnknownFieldJson
 import com.ioki.lokalise.api.stubs.fileUploadJson
 import com.ioki.lokalise.api.stubs.projectsJson
 import com.ioki.lokalise.api.stubs.retrieveProcessJson
@@ -241,6 +242,17 @@ class LokaliseClientTest {
             actual = requestData.url.toString(),
             expected = "https://api.lokalise.com/api2/projects/projectId/processes/processId"
         )
+    }
+
+    @Test
+    fun `test ignore unknown fields`() = runLokaliseTest(fileDownloadWithUnknownFieldJson) { lokalise, mockEngine ->
+        lokalise.downloadFiles(
+            projectId = "projectId",
+            format = "someFormat"
+        )
+
+        val requestData = mockEngine.requestHistory.first()
+        assertHeaders(requestData.headers)
     }
 
     private fun assertHeaders(headers: Headers) = assertTrue {

--- a/src/commonTest/kotlin/com/ioki/lokalise/api/stubs/FileDownloadWithUnknownField.kt
+++ b/src/commonTest/kotlin/com/ioki/lokalise/api/stubs/FileDownloadWithUnknownField.kt
@@ -1,0 +1,9 @@
+package com.ioki.lokalise.api.stubs
+
+val fileDownloadWithUnknownFieldJson = """
+{
+  "project_id": "3002780358964f9bab5a92.87762498",
+  "bundle_url": "https://s3-eu-west-1.amazonaws.com/lokalise-assets/export/MyApp-locale.zip",
+  "unknown_field": 42
+}
+""".trimIndent()


### PR DESCRIPTION
As mentioned in #61 we want to ignore unknown keys in JSON response bodys.